### PR TITLE
Inject CurrencyCode if it doesn't exist

### DIFF
--- a/FacebookEventForwarder.js
+++ b/FacebookEventForwarder.js
@@ -122,6 +122,9 @@ var mpFacebookKit = (function (exports) {
                       if (event.CurrencyCode) {
                           params['currency'] = event.CurrencyCode;
                       }
+                      else{
+                          params['currency'] = 'USD'; // Inject CurrencyCode if it doesn't exist
+                      }
 
                       if (event.EventName) {
                           params['content_name'] = event.EventName;


### PR DESCRIPTION
Facebook requires Purchase events to have valid values for both "value" and "currency". If either of these is invalid or not set, Facebook displays the dashboard error "Missing Purchase Currency Parameter. This may affect your ability to see return on ad spend calculations".