### PR TITLE
Fix CurrencyCode if empty

### DIFF
--- a/src/FacebookEventForwarder.js
+++ b/src/FacebookEventForwarder.js
@@ -107,14 +107,7 @@
                         totalValue,
                         params = cloneEventAttributes(event);
 
-                    if (event.CurrencyCode) {
-                        if (event.CurrencyCode === ""){
-                            params['currency'] = 'USD'; // inject USD if CurrencyCode is empty
-                        }
-                        else {
-                            params['currency'] = event.CurrencyCode;
-                        }
-                    }
+                    params['currency'] = event.CurrencyCode || 'USD'
 
                     if (event.EventName) {
                         params['content_name'] = event.EventName;

--- a/src/FacebookEventForwarder.js
+++ b/src/FacebookEventForwarder.js
@@ -108,7 +108,12 @@
                         params = cloneEventAttributes(event);
 
                     if (event.CurrencyCode) {
-                        params['currency'] = event.CurrencyCode;
+                        if (event.CurrencyCode === ""){
+                            params['currency'] = 'USD'; // inject USD if CurrencyCode is empty
+                        }
+                        else {
+                            params['currency'] = event.CurrencyCode;
+                        }
                     }
 
                     if (event.EventName) {


### PR DESCRIPTION
Facebook requires Purchase events to have valid values for both "value" and "currency". If either of these is invalid or not set, Facebook displays the dashboard error "Missing Purchase Currency Parameter. This may affect your ability to see return on ad spend calculations".