### PR TITLE
feat: Add eventID to enable de-duplicating events

### DIFF
--- a/src/FacebookEventForwarder.js
+++ b/src/FacebookEventForwarder.js
@@ -143,7 +143,7 @@
 
                     var eventName,
                         totalValue,
-                        params = createParameters(event),
+                        params = cloneEventAttributes(event),
                         eventID = createEventId(event);
                     params['currency'] = event.CurrencyCode || 'USD';
 
@@ -256,7 +256,7 @@
             }
 
             function logPageEvent(event, eventName) {
-                var params = createParameters(event);
+                var params = cloneEventAttributes(event);
                 var eventID = createEventId(event);
 
                 eventName = eventName || event.EventName;
@@ -266,7 +266,7 @@
                 fbq('trackCustom', eventName || 'customEvent', params, eventID);
             }
 
-            function createParameters(event) {
+            function cloneEventAttributes(event) {
                 var attr = {};
                 if (event && event.EventAttributes) {
                     try {

--- a/src/FacebookEventForwarder.js
+++ b/src/FacebookEventForwarder.js
@@ -143,8 +143,8 @@
 
                     var eventName,
                         totalValue,
-                        params = cloneEventAttributes(event);
-
+                        params = createParameters(event),
+                        eventID = createEventId(event);
                     params['currency'] = event.CurrencyCode || 'USD';
 
                     if (event.EventName) {
@@ -234,12 +234,12 @@
 
                         params['value'] = totalValue;
 
-                        fbq('trackCustom', eventName || 'customEvent', params);
+                        fbq('trackCustom', eventName || 'customEvent', params, eventID);
                         return true;
                     }
 
                     if (eventName) {
-                        fbq('track', eventName, params);
+                        fbq('track', eventName, params, eventID);
                     }
                     else {
                         return false;
@@ -256,15 +256,17 @@
             }
 
             function logPageEvent(event, eventName) {
-                var params = cloneEventAttributes(event);
+                var params = createParameters(event);
+                var eventID = createEventId(event);
+
                 eventName = eventName || event.EventName;
                 if (event.EventName) {
                     params['content_name'] = event.EventName;
                 }
-                fbq('trackCustom', eventName || 'customEvent', params);
+                fbq('trackCustom', eventName || 'customEvent', params, eventID);
             }
 
-            function cloneEventAttributes(event) {
+            function createParameters(event) {
                 var attr = {};
                 if (event && event.EventAttributes) {
                     try {
@@ -304,6 +306,13 @@
                 }
 
                 return null;
+            }
+
+            // https://developers.facebook.com/docs/marketing-api/conversions-api/deduplicate-pixel-and-server-events#event-deduplication-options
+            function createEventId(event) {
+                return {
+                    eventID: event.SourceMessageId || null
+                }
             }
 
             this.init = initForwarder;

--- a/test/tests.js
+++ b/test/tests.js
@@ -251,7 +251,7 @@ describe('Facebook Forwarder', function () {
             mParticle.forwarder.process({
                 EventName: 'testevent',
                 EventDataType: MessageType.PageView,
-                SourceMessageId: SOURCE_MESSAGE_ID
+                SourceMessageId: SOURCE_MESSAGE_ID,
             });
 
             checkBasicProperties('trackCustom');
@@ -301,7 +301,7 @@ describe('Facebook Forwarder', function () {
             mParticle.forwarder.process({
                 EventName: 'logevent',
                 EventDataType: MessageType.PageEvent,
-                SourceMessageId: SOURCE_MESSAGE_ID
+                SourceMessageId: SOURCE_MESSAGE_ID,
             });
 
             window.fbqObj.eventData.should.have.property('eventID', SOURCE_MESSAGE_ID)
@@ -339,7 +339,7 @@ describe('Facebook Forwarder', function () {
                     ShippingAmount: 10
                 },
                 CurrencyCode: 'USD',
-                SourceMessageId: SOURCE_MESSAGE_ID
+                SourceMessageId: SOURCE_MESSAGE_ID,
             });
 
             checkBasicProperties('track');
@@ -407,7 +407,7 @@ describe('Facebook Forwarder', function () {
                     ShippingAmount: 10
                 },
                 CurrencyCode: 'USD',
-                SourceMessageId: SOURCE_MESSAGE_ID
+                SourceMessageId: SOURCE_MESSAGE_ID,
             });
 
             checkBasicProperties('track');
@@ -451,7 +451,7 @@ describe('Facebook Forwarder', function () {
                     ShippingAmount: 10
                 },
                 CurrencyCode: 'USD',
-                SourceMessageId: SOURCE_MESSAGE_ID
+                SourceMessageId: SOURCE_MESSAGE_ID,
 
             });
 
@@ -510,7 +510,7 @@ describe('Facebook Forwarder', function () {
                     Affiliation: 'my-affiliation'
                 },
                 CurrencyCode: 'USD',
-                SourceMessageId: SOURCE_MESSAGE_ID
+                SourceMessageId: SOURCE_MESSAGE_ID,
             });
 
             checkBasicProperties('track');
@@ -551,7 +551,7 @@ describe('Facebook Forwarder', function () {
                     TotalAmount: 205
                 },
                 CurrencyCode: 'USD',
-                SourceMessageId: SOURCE_MESSAGE_ID
+                SourceMessageId: SOURCE_MESSAGE_ID,
             });
 
             checkBasicProperties('trackCustom');
@@ -591,7 +591,7 @@ describe('Facebook Forwarder', function () {
                     ShippingAmount: 10
                 },
                 CurrencyCode: 'USD',
-                SourceMessageId: SOURCE_MESSAGE_ID
+                SourceMessageId: SOURCE_MESSAGE_ID,
             });
 
             checkBasicProperties('trackCustom');
@@ -653,7 +653,7 @@ describe('Facebook Forwarder', function () {
                     Affiliation: 'my-affiliation'
                 },
                 CurrencyCode: 'USD',
-                SourceMessageId: SOURCE_MESSAGE_ID
+                SourceMessageId: SOURCE_MESSAGE_ID,
             });
 
             checkBasicProperties('track');
@@ -699,7 +699,7 @@ describe('Facebook Forwarder', function () {
                     ShippingAmount: 10
                 },
                 CurrencyCode: 'USD',
-                SourceMessageId: SOURCE_MESSAGE_ID
+                SourceMessageId: SOURCE_MESSAGE_ID,
             });
 
             checkBasicProperties('track');
@@ -746,7 +746,7 @@ describe('Facebook Forwarder', function () {
                     ShippingAmount: 10
                 },
                 CurrencyCode: 'USD',
-                SourceMessageId: SOURCE_MESSAGE_ID
+                SourceMessageId: SOURCE_MESSAGE_ID,
             });
 
             checkBasicProperties('track');
@@ -791,7 +791,7 @@ describe('Facebook Forwarder', function () {
                     ShippingAmount: 10
                 },
                 CurrencyCode: 'USD',
-                SourceMessageId: SOURCE_MESSAGE_ID
+                SourceMessageId: SOURCE_MESSAGE_ID,
             });
 
             checkBasicProperties('track');

--- a/test/tests.js
+++ b/test/tests.js
@@ -105,10 +105,11 @@ describe('Facebook Forwarder', function () {
             self[attr] = true;
         }
 
-        function fbq(fnName, eventname, params) {
+        function fbq(fnName, eventname, params, eventData) {
             setCalledAttributes(fnName + 'Called');
             self.eventName = eventname;
             self.params = params;
+            self.eventData = eventData;
         }
 
         return {
@@ -117,6 +118,7 @@ describe('Facebook Forwarder', function () {
         };
     }
 
+    var SOURCE_MESSAGE_ID = 'Source Message Id Test';
     function checkBasicProperties(fnName) {
         window.fbqObj.should.have.property(fnName + 'Called', true);
         window.fbqObj.should.have.property('eventName');
@@ -244,6 +246,20 @@ describe('Facebook Forwarder', function () {
             window.fbqObj.should.have.property('eventName', 'Viewed testevent');
             done();
         });
+
+        it('should log page view with event id when passed', function (done) {
+            mParticle.forwarder.process({
+                EventName: 'testevent',
+                EventDataType: MessageType.PageView,
+                SourceMessageId: SOURCE_MESSAGE_ID
+            });
+
+            checkBasicProperties('trackCustom');
+            window.fbqObj.should.have.property('eventName', 'Viewed testevent');
+            window.fbqObj.eventData.should.have.property('eventID', SOURCE_MESSAGE_ID)
+
+            done();
+        });
     });
 
     describe('Page Events', function () {
@@ -280,6 +296,17 @@ describe('Facebook Forwarder', function () {
             window.fbqObj.params.should.have.property('foo', 'bar');
             done();
         });
+
+        it('should log event id when passed properly', function (done) {
+            mParticle.forwarder.process({
+                EventName: 'logevent',
+                EventDataType: MessageType.PageEvent,
+                SourceMessageId: SOURCE_MESSAGE_ID
+            });
+
+            window.fbqObj.eventData.should.have.property('eventID', SOURCE_MESSAGE_ID)
+            done();
+        });
     });
 
     describe('Commerce Events', function () {
@@ -311,7 +338,8 @@ describe('Facebook Forwarder', function () {
                     TaxAmount: 40,
                     ShippingAmount: 10
                 },
-                CurrencyCode: 'USD'
+                CurrencyCode: 'USD',
+                SourceMessageId: SOURCE_MESSAGE_ID
             });
 
             checkBasicProperties('track');
@@ -323,6 +351,7 @@ describe('Facebook Forwarder', function () {
             window.fbqObj.params.should.have.property('num_items', 1);
             window.fbqObj.params.should.have.property('eventAttr1', 'value1');
             window.fbqObj.params.should.have.property('eventAttr2', 'value2');
+            window.fbqObj.eventData.should.have.property('eventID', SOURCE_MESSAGE_ID);
 
             done();
         });
@@ -377,7 +406,8 @@ describe('Facebook Forwarder', function () {
                     TaxAmount: 40,
                     ShippingAmount: 10
                 },
-                CurrencyCode: 'USD'
+                CurrencyCode: 'USD',
+                SourceMessageId: SOURCE_MESSAGE_ID
             });
 
             checkBasicProperties('track');
@@ -389,6 +419,8 @@ describe('Facebook Forwarder', function () {
             window.fbqObj.params.should.have.property('content_ids', ['12345', '22', '333']);
             window.fbqObj.params.should.have.property('checkout_step', 1);
             window.fbqObj.params.should.have.property('num_items', 9);
+            window.fbqObj.eventData.should.have.property('eventID', SOURCE_MESSAGE_ID);
+
 
             done();
         });
@@ -418,7 +450,9 @@ describe('Facebook Forwarder', function () {
                     TaxAmount: 40,
                     ShippingAmount: 10
                 },
-                CurrencyCode: 'USD'
+                CurrencyCode: 'USD',
+                SourceMessageId: SOURCE_MESSAGE_ID
+
             });
 
             checkBasicProperties('track');
@@ -427,6 +461,8 @@ describe('Facebook Forwarder', function () {
             window.fbqObj.params.should.have.property('currency', 'USD');
             window.fbqObj.params.should.have.property('content_name', 'eCommerce - AddToCart');
             window.fbqObj.params.should.have.property('content_ids', ['12345']);
+            window.fbqObj.eventData.should.have.property('eventID', SOURCE_MESSAGE_ID);
+
             done();
         });
 
@@ -473,7 +509,8 @@ describe('Facebook Forwarder', function () {
                     TransactionId: 123,
                     Affiliation: 'my-affiliation'
                 },
-                CurrencyCode: 'USD'
+                CurrencyCode: 'USD',
+                SourceMessageId: SOURCE_MESSAGE_ID
             });
 
             checkBasicProperties('track');
@@ -482,6 +519,8 @@ describe('Facebook Forwarder', function () {
             window.fbqObj.params.should.have.property('currency', 'USD');
             window.fbqObj.params.should.have.property('content_name', 'eCommerce - AddToCart');
             window.fbqObj.params.should.have.property('content_ids', ['12345', '888', '666']);
+            window.fbqObj.eventData.should.have.property('eventID', SOURCE_MESSAGE_ID);
+
             done();
         });
 
@@ -511,7 +550,8 @@ describe('Facebook Forwarder', function () {
                     ShippingAmount: 10,
                     TotalAmount: 205
                 },
-                CurrencyCode: 'USD'
+                CurrencyCode: 'USD',
+                SourceMessageId: SOURCE_MESSAGE_ID
             });
 
             checkBasicProperties('trackCustom');
@@ -520,6 +560,7 @@ describe('Facebook Forwarder', function () {
             window.fbqObj.params.should.have.property('currency', 'USD');
             window.fbqObj.params.should.have.property('content_name', 'eCommerce - RemoveFromCart');
             window.fbqObj.params.should.have.property('content_ids', ['12345']);
+            window.fbqObj.eventData.should.have.property('eventID', SOURCE_MESSAGE_ID);
 
             done();
         });
@@ -549,7 +590,8 @@ describe('Facebook Forwarder', function () {
                     TaxAmount: 40,
                     ShippingAmount: 10
                 },
-                CurrencyCode: 'USD'
+                CurrencyCode: 'USD',
+                SourceMessageId: SOURCE_MESSAGE_ID
             });
 
             checkBasicProperties('trackCustom');
@@ -558,6 +600,7 @@ describe('Facebook Forwarder', function () {
             window.fbqObj.params.should.have.property('currency', 'USD');
             window.fbqObj.params.should.have.property('content_name', 'eCommerce - RemoveFromCart');
             window.fbqObj.params.should.have.property('content_ids', ['12345']);
+            window.fbqObj.eventData.should.have.property('eventID', SOURCE_MESSAGE_ID);
 
             done();
         });
@@ -609,7 +652,8 @@ describe('Facebook Forwarder', function () {
                     TransactionId: 123,
                     Affiliation: 'my-affiliation'
                 },
-                CurrencyCode: 'USD'
+                CurrencyCode: 'USD',
+                SourceMessageId: SOURCE_MESSAGE_ID
             });
 
             checkBasicProperties('track');
@@ -620,6 +664,7 @@ describe('Facebook Forwarder', function () {
             window.fbqObj.params.should.have.property('content_ids', ['12345', '888', '666']);
             window.fbqObj.params.should.have.property('eventAttr1', 'value1');
             window.fbqObj.params.should.have.property('eventAttr2', 'value2');
+            window.fbqObj.eventData.should.have.property('eventID', SOURCE_MESSAGE_ID);
 
             done();
         });
@@ -653,7 +698,8 @@ describe('Facebook Forwarder', function () {
                     TaxAmount: 40,
                     ShippingAmount: 10
                 },
-                CurrencyCode: 'USD'
+                CurrencyCode: 'USD',
+                SourceMessageId: SOURCE_MESSAGE_ID
             });
 
             checkBasicProperties('track');
@@ -665,6 +711,7 @@ describe('Facebook Forwarder', function () {
             window.fbqObj.params.should.have.property('content_ids', ['12345']);
             window.fbqObj.params.should.have.property('eventAttr1', 'value1');
             window.fbqObj.params.should.have.property('eventAttr2', 'value2');
+            window.fbqObj.eventData.should.have.property('eventID', SOURCE_MESSAGE_ID);
 
             done();
         });
@@ -698,7 +745,8 @@ describe('Facebook Forwarder', function () {
                     TaxAmount: 40,
                     ShippingAmount: 10
                 },
-                CurrencyCode: 'USD'
+                CurrencyCode: 'USD',
+                SourceMessageId: SOURCE_MESSAGE_ID
             });
 
             checkBasicProperties('track');
@@ -709,6 +757,7 @@ describe('Facebook Forwarder', function () {
             window.fbqObj.params.should.have.property('content_ids', ['145']);
             window.fbqObj.params.should.have.property('eventAttr1', 'value1');
             window.fbqObj.params.should.have.property('eventAttr2', 'value2');
+            window.fbqObj.eventData.should.have.property('eventID', SOURCE_MESSAGE_ID);
 
             done();
         });
@@ -741,7 +790,8 @@ describe('Facebook Forwarder', function () {
                     TaxAmount: 40,
                     ShippingAmount: 10
                 },
-                CurrencyCode: 'USD'
+                CurrencyCode: 'USD',
+                SourceMessageId: SOURCE_MESSAGE_ID
             });
 
             checkBasicProperties('track');
@@ -753,6 +803,8 @@ describe('Facebook Forwarder', function () {
             window.fbqObj.params.should.have.property('content_ids', ['12345']);
             window.fbqObj.params.should.have.property('eventAttr1', 'value1');
             window.fbqObj.params.should.have.property('eventAttr2', 'value2');
+            window.fbqObj.eventData.should.have.property('eventID', SOURCE_MESSAGE_ID);
+
             done();
         });
 


### PR DESCRIPTION
This PR enables de-duplicating events between Facebook's Pixel and Facebook's server side CAPI. 

In order to deduplicate an event, an event object parameter of `{ eventID: 'unique_event_id }` is passed to each of Facebook's `fbq` track/trackCustom methods, per [Facebook de-dupe docs](https://developers.facebook.com/docs/marketing-api/conversions-api/deduplicate-pixel-and-server-events#event-deduplication-options).